### PR TITLE
Target .NET Standard for library code

### DIFF
--- a/KotorDotNET/KotorDotNET.csproj
+++ b/KotorDotNET/KotorDotNET.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
KotorDotNET currently targets NET7.  This PR changes solely the library code to target .net standard 2.0.

It's my understanding for cross-platform support it's important to target .NET Standard at least in library code.

KOTOR is supported from operating systems as early as XP, but to get a nice middle ground of support on older/newer operating systems alike while ensuring cross-platform support across unix, I recommend .NET Standard 2.0 or 2.1.

Thoughts? This assumes you'd like to support older operating systems and hardware.